### PR TITLE
Add export in bulk option

### DIFF
--- a/Sources/ExportKit/Views/ExportView.swift
+++ b/Sources/ExportKit/Views/ExportView.swift
@@ -39,6 +39,11 @@ public struct ExportView: View {
         .navigationTitle("Export")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: viewModel.exportAll) {
+                    Image(systemName: "square.and.arrow.up.on.square")
+                }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: viewModel.load) {
                     Image(systemName: "arrow.counterclockwise")
                 }

--- a/Sources/ExportKit/Views/ExportViewModel.swift
+++ b/Sources/ExportKit/Views/ExportViewModel.swift
@@ -75,8 +75,11 @@ class ExportViewModel: ObservableObject {
 
             if let textItems = items as? [String] {
                 let textToShare = textItems.reduce("") { partialResult, item in
-                    partialResult == "" ? item : partialResult + "\n" + item
-                }
+                    if partialResult.isEmpty {
+                        return item
+                    } else {
+                        return partialResult + "\n" + item
+                    }                }
                 itemsToShare.append(textToShare)
             } else {
                 itemsToShare.append(items)

--- a/Sources/ExportKit/Views/ExportViewModel.swift
+++ b/Sources/ExportKit/Views/ExportViewModel.swift
@@ -41,6 +41,59 @@ class ExportViewModel: ObservableObject {
             alert = .descriptiveError(error.localizedDescription)
         }
     }
+
+    func exportAll() {
+        guard let exportStrategy = ExportKit.shared.exportStrategy else {
+            alert = .descriptiveError("No export strategy")
+            ExportKit.shared.logHandler?("[ EXPORTER ] No export strategy")
+            return
+        }
+
+        guard let topViewController = UIApplication.topViewController() else {
+            alert = .descriptiveError("No Top View Controller")
+            ExportKit.shared.logHandler?("[ EXPORTER ] No Top View Controller")
+            return
+        }
+
+        let results = data.reduce(.success([Item]())) { (partialResult, item) -> Result<[Any], Error> in
+            switch partialResult {
+            case .failure(_):
+                return partialResult
+            case .success(let array):
+                switch exportStrategy(item) {
+                case .success(let itemResult):
+                    return .success(array + CollectionOfOne(itemResult))
+                case .failure(let error):
+                    return .failure(error)
+                }
+            }
+        }
+
+        switch results {
+        case .success(let items):
+            var itemsToShare = [Any]()
+
+            if let textItems = items as? [String] {
+                let textToShare = textItems.reduce("") { partialResult, item in
+                    partialResult == "" ? item : partialResult + "\n" + item
+                }
+                itemsToShare.append(textToShare)
+            } else {
+                itemsToShare.append(items)
+            }
+
+            let activityViewController = UIActivityViewController(activityItems: itemsToShare, applicationActivities: nil)
+
+            if UIDevice.current.userInterfaceIdiom == .pad {
+                activityViewController.popoverPresentationController?.sourceView = topViewController.view
+                activityViewController.popoverPresentationController?.sourceRect = CGRect(x: UIScreen.main.bounds.width / 2, y: UIScreen.main.bounds.height / 2, width: 0, height: 0)
+                activityViewController.popoverPresentationController?.permittedArrowDirections = []
+            }
+            topViewController.present(activityViewController, animated: true, completion: nil)
+        case .failure(let error):
+            alert = .descriptiveError(error.localizedDescription)
+        }
+    }
     
     func delete(at offsets: IndexSet) {
         offsets.forEach {

--- a/Sources/ExportKit/Views/ExportViewModel.swift
+++ b/Sources/ExportKit/Views/ExportViewModel.swift
@@ -79,7 +79,8 @@ class ExportViewModel: ObservableObject {
                         return item
                     } else {
                         return partialResult + "\n" + item
-                    }                }
+                    }
+                }
                 itemsToShare.append(textToShare)
             } else {
                 itemsToShare.append(items)


### PR DESCRIPTION
Added export in bulk option to the ViewModel. This option can be run by tapping the new icon on the toolbar. All saved items are collected and passed to UIActivityViewController as an array. If the items are of String type, they are concatenated in a single text file with each line containing one item. 

![Simulator Screen Shot - iPhone 14 Pro - 2023-03-19 at 22 12 51](https://user-images.githubusercontent.com/35854230/226209902-31238ff8-36e6-463d-91ed-b6d7c901b67d.png)
